### PR TITLE
Use Azure SQL Edge instead of SqlServer

### DIFF
--- a/docker-compose.services.yml
+++ b/docker-compose.services.yml
@@ -1,6 +1,7 @@
 version: "3.8"
 
-x-loki-logging: &loki-logging
+x-loki-logging:
+  &loki-logging
   driver: loki
   options:
     loki-url: http://localhost:3100/loki/api/v1/push
@@ -17,22 +18,22 @@ services:
       - "5672:5672"
       - "15672:15672"
       - "15692:15692"
-  
+
   mssql:
-    image: "mcr.microsoft.com/mssql/server:2017-latest"
+    image: "mcr.microsoft.com/azure-sql-edge:latest"
     environment:
       - "ACCEPT_EULA=Y"
       - "SA_PASSWORD=Password12!"
     ports:
       - 1433:1433
-  
+
   seq:
     image: datalust/seq:latest
     environment:
       ACCEPT_EULA: "Y"
     ports:
       - "5341:80"
-  
+
   jaeger:
     image: jaegertracing/all-in-one:latest
     ports:
@@ -51,7 +52,7 @@ services:
     command:
       - -config.file=/etc/tempo-config.yaml
     ports:
-      - "4317:4317"  # gRPC
+      - "4317:4317" # gRPC
     depends_on:
       - loki
     logging: *loki-logging
@@ -77,13 +78,13 @@ services:
     configs:
       - source: prometheus-config
         target: /etc/prometheus.yaml
-        
+
   grafana-agent:
     image: grafana/agent:latest
     command: "-config.file=/etc/agent-config.yaml"
     ports:
-      - "14317:4317"   # gRPC
-      - "14318:4318"   # http
+      - "14317:4317" # gRPC
+      - "14318:4318" # http
     configs:
       - source: grafana-agent-config
         target: /etc/agent-config.yaml


### PR DESCRIPTION
Microsoft SQL Server is only compatible with x86-64 host architecture. This means we cannot run Docker Compose in ARM environment, most notably in macOS on Apple Silicon. While there is an emulation mode for x86-64 images in macOS (Rosetta 2), it is not good enough - SQL Server x86-64 image crashed once we start using it.

Alternative is to use Azure SQL Edge
https://azure.microsoft.com/en-gb/products/azure-sql/edge/#product-overview

It may have some limitations in terms of supported features compared to the full SQL Server, but it is perfectly adequate for the purpose of this demo application.